### PR TITLE
fix: introduce explicit marshaler

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,10 +2,8 @@
 #
 # Generated on 2022-09-14T10:28:03Z by kres 2e9342e.
 
-**
-!pkg
-!go.mod
-!go.sum
-!.golangci.yml
-!README.md
-!.markdownlint.json
+{
+    "MD013": false,
+    "MD033": false,
+    "default": true
+  }

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,28 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-08-26T17:09:03Z by kres latest.
+# Generated on 2022-09-14T10:28:03Z by kres 2e9342e.
 
 ARG TOOLCHAIN
 
 # cleaned up specs and compiled versions
 FROM scratch AS generate
 
+# runs markdownlint
+FROM docker.io/node:18.9.0-alpine3.16 AS lint-markdown
+WORKDIR /src
+RUN npm i -g markdownlint-cli@0.32.2
+RUN npm i sentences-per-line@0.2.1
+COPY .markdownlint.json .
+COPY ./README.md ./README.md
+RUN markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules node_modules/sentences-per-line/index.js .
+
 # base toolchain image
 FROM ${TOOLCHAIN} AS toolchain
 RUN apk --update --no-cache add bash curl build-base protoc protobuf-dev
 
 # build tools
-FROM toolchain AS tools
+FROM --platform=${BUILDPLATFORM} toolchain AS tools
 ENV GO111MODULE on
 ENV CGO_ENABLED 0
 ENV GOPATH /go

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-08-26T17:09:03Z by kres latest.
+# Generated on 2022-09-14T10:28:03Z by kres 2e9342e.
 
 # common variables
 
@@ -17,7 +17,7 @@ GO_VERSION ?= 1.19
 GOIMPORTS_VERSION ?= v0.1.12
 PROTOBUF_GO_VERSION ?= 1.28.1
 GRPC_GO_VERSION ?= 1.2.0
-GRPC_GATEWAY_VERSION ?= 2.11.1
+GRPC_GATEWAY_VERSION ?= 2.11.3
 VTPROTOBUF_VERSION ?= 0.3.0
 DEEPCOPY_VERSION ?= v0.5.5
 TESTPKGS ?= ./...
@@ -39,6 +39,7 @@ COMMON_ARGS += --build-arg=ARTIFACTS=$(ARTIFACTS)
 COMMON_ARGS += --build-arg=SHA=$(SHA)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
+COMMON_ARGS += --build-arg=REGISTRY=$(REGISTRY)
 COMMON_ARGS += --build-arg=TOOLCHAIN=$(TOOLCHAIN)
 COMMON_ARGS += --build-arg=GOLANGCILINT_VERSION=$(GOLANGCILINT_VERSION)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)
@@ -128,8 +129,12 @@ unit-tests-race:  ## Performs unit tests with race detection enabled.
 coverage:  ## Upload coverage data to codecov.io.
 	bash -c "bash <(curl -s https://codecov.io/bash) -f $(ARTIFACTS)/coverage.txt -X fix"
 
+.PHONY: lint-markdown
+lint-markdown:  ## Runs markdownlint.
+	@$(MAKE) target-$@
+
 .PHONY: lint
-lint: lint-golangci-lint lint-gofumpt lint-goimports  ## Run all linters for the project.
+lint: lint-golangci-lint lint-gofumpt lint-goimports lint-markdown  ## Run all linters for the project.
 
 .PHONY: rekres
 rekres:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# COSI `etcd` State Storage
+
+This project implements [COSI](https://github.com/cosi-project/runtime) state (resource storage) in `etcd` database.
+
+This allows concurrent access to the state by multiple COSI runtime instances.

--- a/pkg/state/impl/etcd/etcd.go
+++ b/pkg/state/impl/etcd/etcd.go
@@ -34,8 +34,11 @@ type State struct {
 	salt      []byte
 }
 
+// Check interface implementation.
+var _ state.CoreState = &State{}
+
 // NewState creates new State with default options.
-func NewState(cli Client, opts ...StateOption) *State {
+func NewState(cli Client, marshaler store.Marshaler, opts ...StateOption) *State {
 	options := DefaultStateOptions()
 
 	for _, opt := range opts {
@@ -44,7 +47,7 @@ func NewState(cli Client, opts ...StateOption) *State {
 
 	return &State{
 		cli:       cli,
-		marshaler: store.ProtobufMarshaler{},
+		marshaler: marshaler,
 		keyPrefix: options.keyPrefix,
 		salt:      options.salt,
 	}

--- a/pkg/state/impl/etcd/etcd_test.go
+++ b/pkg/state/impl/etcd/etcd_test.go
@@ -14,19 +14,13 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource/protobuf"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/conformance"
-	"github.com/stretchr/testify/assert"
+	"github.com/cosi-project/runtime/pkg/state/impl/store"
 	"github.com/stretchr/testify/suite"
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/v3client"
 
 	"github.com/cosi-project/state-etcd/pkg/state/impl/etcd"
 )
-
-func TestInterfaces(t *testing.T) {
-	t.Parallel()
-
-	assert.Implements(t, (*state.CoreState)(nil), new(etcd.State))
-}
 
 func TestEtcdConformance(t *testing.T) {
 	t.Parallel()
@@ -91,7 +85,7 @@ func withEtcd(t *testing.T, f func(state.State)) {
 
 	defer cli.Close() //nolint:errcheck
 
-	etcdState := etcd.NewState(cli, etcd.WithSalt([]byte("test123")))
+	etcdState := etcd.NewState(cli, store.ProtobufMarshaler{}, etcd.WithSalt([]byte("test123")))
 	st := state.WrapCore(etcdState)
 
 	f(st)


### PR DESCRIPTION
Accept explicit marshaler, as every usage might be different - e.g. using encryption on top of protobuf.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>