### PR TITLE
fix: use PathEscape instead of QueryEscape

### DIFF
--- a/pkg/state/impl/etcd/key.go
+++ b/pkg/state/impl/etcd/key.go
@@ -23,8 +23,8 @@ func (st *State) etcdKeyFromPointer(pointer resource.Pointer) string {
 
 // etcdKeyPrefixFromKind returns a key prefix for the given resource kind.
 func (st *State) etcdKeyPrefixFromKind(kind resource.Kind) string {
-	nsEscaped := url.QueryEscape(kind.Namespace())
-	typeEscaped := url.QueryEscape(kind.Type())
+	nsEscaped := url.PathEscape(kind.Namespace())
+	typeEscaped := url.PathEscape(kind.Type())
 
 	return st.keyPrefix + "/" + nsEscaped + "/" + typeEscaped + "/"
 }


### PR DESCRIPTION
I believe that is the intention - replace `/` to avoid mismatches on prefixes.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>