### PR TITLE
fix: ignore correctly bootstrapped duplicates in WatchKind

### DIFF
--- a/pkg/state/impl/etcd/controller_runtime_test.go
+++ b/pkg/state/impl/etcd/controller_runtime_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource/protobuf"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/store"
-	"github.com/stretchr/testify/require"
 	suiterunner "github.com/stretchr/testify/suite"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
@@ -21,12 +20,20 @@ import (
 	"github.com/cosi-project/state-etcd/pkg/util/testhelpers"
 )
 
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func init() {
+	must(protobuf.RegisterResource(conformance.IntResourceType, &conformance.IntResource{}))
+	must(protobuf.RegisterResource(conformance.StrResourceType, &conformance.StrResource{}))
+	must(protobuf.RegisterResource(conformance.SentenceResourceType, &conformance.SentenceResource{}))
+}
+
 func TestRuntimeConformance(t *testing.T) {
 	t.Parallel()
-
-	require.NoError(t, protobuf.RegisterResource(conformance.IntResourceType, &conformance.IntResource{}))
-	require.NoError(t, protobuf.RegisterResource(conformance.StrResourceType, &conformance.StrResource{}))
-	require.NoError(t, protobuf.RegisterResource(conformance.SentenceResourceType, &conformance.SentenceResource{}))
 
 	testhelpers.WithEtcd(t, func(cli *clientv3.Client) {
 		suite := &conformance.RuntimeSuite{}

--- a/pkg/state/impl/etcd/etcd_test.go
+++ b/pkg/state/impl/etcd/etcd_test.go
@@ -6,7 +6,6 @@ package etcd_test
 
 import (
 	"context"
-	"log"
 	"testing"
 	"time"
 
@@ -23,10 +22,7 @@ import (
 )
 
 func init() {
-	err := protobuf.RegisterResource(conformance.PathResourceType, &conformance.PathResource{})
-	if err != nil {
-		log.Fatalf("failed to register resource: %v", err)
-	}
+	must(protobuf.RegisterResource(conformance.PathResourceType, &conformance.PathResource{}))
 }
 
 func TestPreserveCreated(t *testing.T) {

--- a/pkg/state/impl/etcd/watch_test.go
+++ b/pkg/state/impl/etcd/watch_test.go
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package etcd_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/conformance"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatchKindWithBootstrap(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name                      string
+		destroyIsTheLastOperation bool
+	}{
+		{
+			name:                      "put is last",
+			destroyIsTheLastOperation: false,
+		},
+		{
+			name:                      "delete is last",
+			destroyIsTheLastOperation: true,
+		},
+	} {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			withEtcd(t, func(s state.State) {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				for i := 0; i < 3; i++ {
+					require.NoError(t, s.Create(ctx, conformance.NewPathResource("default", fmt.Sprintf("path-%d", i))))
+				}
+
+				if test.destroyIsTheLastOperation {
+					require.NoError(t, s.Create(ctx, conformance.NewPathResource("default", "path-3")))
+					require.NoError(t, s.Destroy(ctx, conformance.NewPathResource("default", "path-3").Metadata()))
+				}
+
+				watchCh := make(chan state.Event)
+
+				require.NoError(t, s.WatchKind(ctx, conformance.NewPathResource("default", "").Metadata(), watchCh, state.WithBootstrapContents(true)))
+
+				for i := 0; i < 3; i++ {
+					select {
+					case <-time.After(time.Second):
+						t.Fatal("timeout waiting for event")
+					case ev := <-watchCh:
+						assert.Equal(t, state.Created, ev.Type)
+						assert.Equal(t, fmt.Sprintf("path-%d", i), ev.Resource.Metadata().ID())
+						assert.IsType(t, &conformance.PathResource{}, ev.Resource)
+					}
+				}
+
+				select {
+				case <-time.After(time.Second):
+					t.Fatal("timeout waiting for event")
+				case ev := <-watchCh:
+					assert.Equal(t, state.Bootstrapped, ev.Type)
+				}
+
+				require.NoError(t, s.Destroy(ctx, conformance.NewPathResource("default", "path-0").Metadata()))
+
+				select {
+				case <-time.After(time.Second):
+					t.Fatal("timeout waiting for event")
+				case ev := <-watchCh:
+					assert.Equal(t, state.Destroyed, ev.Type, "event %s %s", ev.Type, ev.Resource)
+					assert.Equal(t, "path-0", ev.Resource.Metadata().ID())
+					assert.IsType(t, &conformance.PathResource{}, ev.Resource)
+				}
+
+				newR, err := safe.StateUpdateWithConflicts(ctx, s, conformance.NewPathResource("default", "path-1").Metadata(), func(r *conformance.PathResource) error {
+					r.Metadata().Finalizers().Add("foo")
+
+					return nil
+				})
+				require.NoError(t, err)
+
+				select {
+				case <-time.After(time.Second):
+					t.Fatal("timeout waiting for event")
+				case ev := <-watchCh:
+					assert.Equal(t, state.Updated, ev.Type, "event %s %s", ev.Type, ev.Resource)
+					assert.Equal(t, "path-1", ev.Resource.Metadata().ID())
+					assert.Equal(t, newR.Metadata().Finalizers(), ev.Resource.Metadata().Finalizers())
+					assert.Equal(t, newR.Metadata().Version(), ev.Resource.Metadata().Version())
+					assert.IsType(t, &conformance.PathResource{}, ev.Resource)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
Previous implementation had a bug when it might ignore an event coming for a resource which was deleted and then recreated under the same resource version.

Co-authored-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>
Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>