### PR TITLE
chore: bump deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: docker/setup-qemu-action@v2.2.0
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.9.0
+        uses: docker/setup-buildx-action@v2.9.1
       -
         name: base
         run: make base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# syntax = docker/dockerfile-upstream:1.5.2-labs
+# syntax = docker/dockerfile-upstream:1.6.0-labs
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2023-07-10T12:50:35Z by kres latest.
+# Generated on 2023-07-18T18:27:24Z by kres latest.
 
 ARG TOOLCHAIN
 
@@ -10,7 +10,7 @@ ARG TOOLCHAIN
 FROM scratch AS generate
 
 # runs markdownlint
-FROM docker.io/node:20.3.1-alpine3.18 AS lint-markdown
+FROM docker.io/node:20.4.0-alpine3.18 AS lint-markdown
 WORKDIR /src
 RUN npm i -g markdownlint-cli@0.34.0
 RUN npm i sentences-per-line@0.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cosi-project/state-etcd
 go 1.20
 
 require (
-	github.com/cosi-project/runtime v0.3.1-alpha.6
+	github.com/cosi-project/runtime v0.3.1-alpha.8
 	github.com/siderolabs/gen v0.4.5
 	github.com/stretchr/testify v1.8.4
 	go.etcd.io/etcd/api/v3 v3.5.9

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmf
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cosi-project/runtime v0.3.1-alpha.6 h1:ANIuJwAKyjGvmy3fvnO/wqNC8lkPN458cKVudjHuGEs=
-github.com/cosi-project/runtime v0.3.1-alpha.6/go.mod h1:x8rgrf77fIK161zSeDqAwjSkOhQfqCrVJsvTuNr4w0E=
+github.com/cosi-project/runtime v0.3.1-alpha.8 h1:7OTWghF4Og3Uixwzuw2RWGRO+UjuPFFlRLiMgNeqNl8=
+github.com/cosi-project/runtime v0.3.1-alpha.8/go.mod h1:n6rQ/b9GkrniSslnrFId6dzWDG+htbcC9fW+f3f1K94=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Bump deps:
- run rekres
- github.com/cosi-project/runtime to v0.3.1-alpha.8
- docker/setup-buildx-action to v2.9.1