### PR TITLE
fix: filter watch events on revision

### DIFF
--- a/pkg/state/impl/etcd/etcd.go
+++ b/pkg/state/impl/etcd/etcd.go
@@ -438,6 +438,10 @@ func (st *State) Watch(ctx context.Context, resourcePointer resource.Pointer, ch
 			}
 
 			for _, etcdEvent := range watchResponse.Events {
+				if etcdEvent.Kv != nil && etcdEvent.Kv.ModRevision <= revision {
+					continue
+				}
+
 				event, err := st.convertEvent(etcdEvent)
 				if err != nil {
 					channel.SendWithContext(ctx, ch,

--- a/pkg/state/impl/etcd/watch_test.go
+++ b/pkg/state/impl/etcd/watch_test.go
@@ -102,3 +102,46 @@ func TestWatchKindWithBootstrap(t *testing.T) {
 		})
 	}
 }
+
+func TestWatchSpuriousEvents(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t, goleak.IgnoreCurrent()) })
+
+	withEtcd(t, func(s state.State) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+
+		const N = 100
+
+		for i := range N {
+			require.NoError(t, s.Create(ctx, conformance.NewPathResource("default", fmt.Sprintf("path-%d", i))))
+		}
+
+		watchCh := make(chan state.Event)
+
+		for i := range N {
+			require.NoError(t, s.Watch(ctx, conformance.NewPathResource("default", fmt.Sprintf("path-%d", i)).Metadata(), watchCh))
+		}
+
+		for range N {
+			select {
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for event")
+			case ev := <-watchCh:
+				assert.Equal(t, state.Created, ev.Type)
+			}
+		}
+
+		for i := range N {
+			require.NoError(t, s.Destroy(ctx, conformance.NewPathResource("default", fmt.Sprintf("path-%d", i)).Metadata()))
+		}
+
+		for range N {
+			select {
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for event")
+			case ev := <-watchCh:
+				assert.Equal(t, state.Destroyed, ev.Type, "ev: %v", ev.Resource)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Similar bug was discovered in `WatchKind` earlier.

Add a regression test for the bug.