### PR TITLE
 fix: ignore version conflicts in destroy calls

### DIFF
--- a/pkg/state/impl/etcd/etcd.go
+++ b/pkg/state/impl/etcd/etcd.go
@@ -330,9 +330,11 @@ func (st *State) Destroy(ctx context.Context, resourcePointer resource.Pointer, 
 	var foundVersion int64
 
 	txnGetKvs := txnResp.Responses[0].GetResponseRange().Kvs
-	if len(txnResp.Responses[0].GetResponseRange().Kvs) > 0 {
-		foundVersion = txnGetKvs[0].Version
+	if len(txnGetKvs) == 0 {
+		return nil
 	}
+
+	foundVersion = txnGetKvs[0].Version
 
 	return fmt.Errorf("failed to destroy: %w", ErrVersionConflict(resourcePointer, etcdVersion, foundVersion))
 }


### PR DESCRIPTION
Add a small reproducer.
Make the destroy code treat not found version as successful deletion.