### PR TITLE
feat: add limiter callback for gating state mutations

### DIFF
--- a/pkg/state/impl/etcd/etcd.go
+++ b/pkg/state/impl/etcd/etcd.go
@@ -39,6 +39,7 @@ type State struct {
 	cli       Client
 	marshaler store.Marshaler
 	observer  ObserverFunc
+	limiter   LimiterFunc
 	keyPrefix string
 	salt      []byte
 }
@@ -58,23 +59,40 @@ func NewState(cli Client, marshaler store.Marshaler, opts ...StateOption) *State
 		cli:       cli,
 		marshaler: marshaler,
 		observer:  options.observer,
+		limiter:   options.limiter,
 		keyPrefix: options.keyPrefix,
 		salt:      options.salt,
 	}
 }
 
-func (st *State) observe(ctx context.Context, eventType state.EventType, resourceType resource.Type, phase, previousPhase resource.Phase, marshaledBytes int) (err error) {
-	if st.observer == nil {
+func (st *State) invokeHook(
+	ctx context.Context,
+	name string,
+	fn func(context.Context, state.EventType, resource.Type, resource.Phase, resource.Phase, int) error,
+	eventType state.EventType,
+	resourceType resource.Type,
+	phase, previousPhase resource.Phase,
+	marshaledBytes int,
+) (err error) {
+	if fn == nil {
 		return nil
 	}
 
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("observer panicked: %v\n%s", r, debug.Stack())
+			err = fmt.Errorf("%s panicked: %v\n%s", name, r, debug.Stack())
 		}
 	}()
 
-	return st.observer(ctx, eventType, resourceType, phase, previousPhase, marshaledBytes)
+	return fn(ctx, eventType, resourceType, phase, previousPhase, marshaledBytes)
+}
+
+func (st *State) observe(ctx context.Context, eventType state.EventType, resourceType resource.Type, phase, previousPhase resource.Phase, marshaledBytes int) error {
+	return st.invokeHook(ctx, "observer", st.observer, eventType, resourceType, phase, previousPhase, marshaledBytes)
+}
+
+func (st *State) limit(ctx context.Context, eventType state.EventType, resourceType resource.Type, phase, previousPhase resource.Phase, marshaledBytes int) error {
+	return st.invokeHook(ctx, "limiter", st.limiter, eventType, resourceType, phase, previousPhase, marshaledBytes)
 }
 
 // Get a resource.
@@ -176,6 +194,10 @@ func (st *State) Create(ctx context.Context, res resource.Resource, opts ...stat
 		return fmt.Errorf("failed to marshal on create %q: %w", resCopy.Metadata(), err)
 	}
 
+	if err = st.limit(ctx, state.Created, resCopy.Metadata().Type(), resCopy.Metadata().Phase(), resCopy.Metadata().Phase(), len(data)); err != nil {
+		return err
+	}
+
 	txnResp, err := st.cli.Txn(ctx).If(
 		clientv3.Compare(clientv3.Version(etcdKey), "=", 0), // not exists check
 	).Then(
@@ -263,6 +285,10 @@ func (st *State) Update(ctx context.Context, res resource.Resource, opts ...stat
 		return fmt.Errorf("failed to update: %w", ErrPhaseConflict(curResource.Metadata(), *options.ExpectedPhase))
 	}
 
+	if err = st.limit(ctx, state.Updated, resCopy.Metadata().Type(), resCopy.Metadata().Phase(), curResource.Metadata().Phase(), len(data)); err != nil {
+		return err
+	}
+
 	txnResp, err := st.cli.Txn(ctx).If(
 		clientv3.Compare(clientv3.Version(etcdKey), "=", etcdVersion),
 	).Then(
@@ -342,6 +368,10 @@ func (st *State) Destroy(ctx context.Context, resourcePointer resource.Pointer, 
 	}
 
 	deletedBytes := len(resp.Kvs[0].Value)
+
+	if err = st.limit(ctx, state.Destroyed, resourcePointer.Type(), curResource.Metadata().Phase(), curResource.Metadata().Phase(), deletedBytes); err != nil {
+		return err
+	}
 
 	txnResp, err := st.cli.Txn(ctx).If(
 		clientv3.Compare(clientv3.Version(etcdKey), "=", etcdVersion),

--- a/pkg/state/impl/etcd/limiter_test.go
+++ b/pkg/state/impl/etcd/limiter_test.go
@@ -1,0 +1,184 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package etcd_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/conformance"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosi-project/state-etcd/pkg/state/impl/etcd"
+)
+
+type limitCall struct {
+	rType         resource.Type
+	phase         resource.Phase
+	previousPhase resource.Phase
+	eventType     state.EventType
+	bytes         int
+}
+
+type recordingLimiter struct {
+	rejects map[state.EventType]error
+	calls   []limitCall
+	mu      sync.Mutex
+}
+
+func (r *recordingLimiter) gate(_ context.Context, eventType state.EventType, rType resource.Type, phase, previousPhase resource.Phase, marshaledBytes int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.calls = append(r.calls, limitCall{
+		rType:         rType,
+		phase:         phase,
+		previousPhase: previousPhase,
+		eventType:     eventType,
+		bytes:         marshaledBytes,
+	})
+
+	if err, ok := r.rejects[eventType]; ok {
+		return err
+	}
+
+	return nil
+}
+
+func (r *recordingLimiter) snapshot() []limitCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.calls)
+}
+
+func TestLimiterFiresBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	lim := &recordingLimiter{}
+
+	withEtcd(t, func(s state.State) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		res := conformance.NewPathResource("default", "/limiter-success")
+
+		require.NoError(t, s.Create(ctx, res))
+		require.NoError(t, s.Update(ctx, res))
+		require.NoError(t, s.Destroy(ctx, res.Metadata()))
+
+		got := lim.snapshot()
+		require.Len(t, got, 3)
+
+		assert.Equal(t, state.Created, got[0].eventType)
+		assert.Positive(t, got[0].bytes)
+
+		assert.Equal(t, state.Updated, got[1].eventType)
+		assert.Positive(t, got[1].bytes)
+
+		assert.Equal(t, state.Destroyed, got[2].eventType)
+		// destroy reports the size of the previously stored payload
+		assert.Equal(t, got[1].bytes, got[2].bytes)
+	}, etcd.WithLimiter(lim.gate))
+}
+
+func TestLimiterRejectionAbortsMutation(t *testing.T) {
+	t.Parallel()
+
+	createErr := errors.New("limiter rejected create")
+
+	lim := &recordingLimiter{rejects: map[state.EventType]error{state.Created: createErr}}
+
+	withEtcd(t, func(s state.State) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		res := conformance.NewPathResource("default", "/limiter-reject-create")
+
+		err := s.Create(ctx, res)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, createErr)
+
+		// rejected mutation did not commit
+		_, getErr := s.Get(ctx, res.Metadata())
+		assert.True(t, state.IsNotFoundError(getErr))
+	}, etcd.WithLimiter(lim.gate))
+}
+
+func TestLimiterDoesNotFireOnPreconditionFailures(t *testing.T) {
+	t.Parallel()
+
+	lim := &recordingLimiter{}
+
+	withEtcd(t, func(s state.State) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		res := conformance.NewPathResource("default", "/limiter-precondition")
+
+		// Bring the resource into existence; one Create gate call.
+		require.NoError(t, s.Create(ctx, res))
+
+		// Updating a missing resource fails in the precondition Get, before the limiter.
+		missing := conformance.NewPathResource("default", "/limiter-missing")
+		err := s.Update(ctx, missing)
+		require.Error(t, err)
+		assert.True(t, state.IsNotFoundError(err))
+
+		// Destroying a missing resource fails the same way.
+		err = s.Destroy(ctx, missing.Metadata())
+		require.Error(t, err)
+		assert.True(t, state.IsNotFoundError(err))
+
+		got := lim.snapshot()
+		require.Len(t, got, 1)
+		assert.Equal(t, state.Created, got[0].eventType)
+	}, etcd.WithLimiter(lim.gate))
+}
+
+func TestLimiterPanicPropagates(t *testing.T) {
+	t.Parallel()
+
+	panicking := func(context.Context, state.EventType, resource.Type, resource.Phase, resource.Phase, int) error {
+		panic("limiter boom")
+	}
+
+	withEtcd(t, func(s state.State) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		res := conformance.NewPathResource("default", "/limiter-panic")
+
+		err := s.Create(ctx, res)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "limiter panicked")
+		assert.Contains(t, err.Error(), "limiter boom")
+
+		// mutation was aborted; resource not in etcd
+		_, getErr := s.Get(ctx, res.Metadata())
+		assert.True(t, state.IsNotFoundError(getErr))
+	}, etcd.WithLimiter(panicking))
+}
+
+func TestLimiterNilNoop(t *testing.T) {
+	t.Parallel()
+
+	withEtcd(t, func(s state.State) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		res := conformance.NewPathResource("default", "/limiter-nil")
+
+		require.NoError(t, s.Create(ctx, res))
+		require.NoError(t, s.Update(ctx, res))
+		require.NoError(t, s.Destroy(ctx, res.Metadata()))
+	})
+}

--- a/pkg/state/impl/etcd/options.go
+++ b/pkg/state/impl/etcd/options.go
@@ -16,9 +16,16 @@ import (
 // to resource.PhaseTearingDown.
 type ObserverFunc func(ctx context.Context, eventType state.EventType, resourceType resource.Type, phase, previousPhase resource.Phase, marshaledBytes int) error
 
+// LimiterFunc is invoked before each Create, Update, or Destroy etcd transaction.
+// Returning a non-nil error aborts the mutation and propagates the error to the caller.
+// For Create/Update, marshaledBytes is the size of the payload about to be written.
+// For Destroy, marshaledBytes is the size of the existing value about to be deleted.
+type LimiterFunc func(ctx context.Context, eventType state.EventType, resourceType resource.Type, phase, previousPhase resource.Phase, marshaledBytes int) error
+
 // StateOptions configure etcd.State.
 type StateOptions struct {
 	observer  ObserverFunc
+	limiter   LimiterFunc
 	keyPrefix string
 	salt      []byte
 }
@@ -55,5 +62,20 @@ func WithKeyPrefix(keyPrefix string) StateOption {
 func WithObserver(fn ObserverFunc) StateOption {
 	return func(options *StateOptions) {
 		options.observer = fn
+	}
+}
+
+// WithLimiter registers a callback that is invoked before each Create, Update, or Destroy
+// etcd transaction. The callback may return an error to abort the mutation; the error is
+// propagated to the caller without any state change.
+//
+// The limiter runs after local validations (owner, version, phase, finalizers) and before
+// the etcd transaction. For Create, the existence check is part of the transaction itself,
+// so the limiter may fire for a key that turns out to already exist. For Update and Destroy,
+// the transaction may still fail due to a concurrent writer after the limiter accepts.
+// Limiters that count against a budget should tolerate these post-accept failures.
+func WithLimiter(fn LimiterFunc) StateOption {
+	return func(options *StateOptions) {
+		options.limiter = fn
 	}
 }


### PR DESCRIPTION
Introduce a LimiterFunc hook invoked before each Create, Update, or Destroy etcd transaction so callers can enforce per-resource quotas or rate limits.
